### PR TITLE
Fix typo in property

### DIFF
--- a/docs/Properties.md
+++ b/docs/Properties.md
@@ -128,7 +128,7 @@
 | ` padding-right ` | `rechtervulling` |
 | ` padding-top ` | `bovenvulling` |
 | ` padding ` | `vulling` |
-| ` perspective-origin ` | `perspectief-oorspring` |
+| ` perspective-origin ` | `perspectief-oorsprong` |
 | ` perspective ` | `perspectief` |
 | ` pointer-events ` | `aanwijzergebeurtenis` |
 | ` position ` | `positie` |

--- a/src/properties.js
+++ b/src/properties.js
@@ -126,7 +126,7 @@ export default {
   'padding-right': 'rechtervulling',
   'padding-top': 'bovenvulling',
   'padding': 'vulling',
-  'perspective-origin': 'perspectief-oorspring',
+  'perspective-origin': 'perspectief-oorsprong',
   'perspective': 'perspectief',
   'pointer-events': 'aanwijzergebeurtenis',
   'position': 'positie',


### PR DESCRIPTION
the property `perspective-origin` was erroneously translated as `perspectief-oorspring`, which should be `perspectief-oorsprong` (with an `o`).
